### PR TITLE
Add additional SharedXML paths from TWW and SoD phase 4

### DIFF
--- a/browser.lua
+++ b/browser.lua
@@ -70,8 +70,12 @@ local function TraceCVar(cvar, value, ...)
       lineNum = "(unhandled exception)"
     end
   end
-  -- Ignore C_CVar.SetCVar hook if it originated from CvarUtil.lua or ClassicCvarUtil.lua
-  if source and not (source:lower():find("[_\\/]sharedxml[\\/]cvarutil%.lua") or source:lower():find("[_\\/]sharedxml[\\/]classiccvarutil%.lua")) then
+  -- Ignore C_CVar.SetCVar hook if it originated from ourselves or CvarUtil.lua or ClassicCvarUtil.lua
+  if source and not (source:lower():find("[\\/]advancedinterfaceoptions[\\/]") or
+          source:lower():find("[_\\/]sharedxmlbase[\\/]cvarutil%.lua") or
+          source:lower():find("[_\\/]sharedxml[\\/]cvarutil%.lua") or
+          source:lower():find("[_\\/]sharedxml[\\/]classiccvarutil%.lua") or
+          source:lower():find("[_\\/]sharedxml[\\/]classic[\\/]classiccvarutil%.lua")) then
     local realValue = GetCVar(cvar) -- the client does some conversions to the original value
     if SVLoaded then
       AdvancedInterfaceOptionsSaved.ModifiedCVars[cvar:lower()] = source .. ":" .. lineNum


### PR DESCRIPTION
I noticed SoD P4 changed the path to ClassicCvarUtil (again) and TWW also added SharedXMLBase (sigh).

I also added AIO itself to the SetCVar ignore hook otherwise we ignore cvars we set ourselves when enforcing (noticed in TWW testing).