### PR TITLE
Create a new panel for camera options + add new Camera Collision setting

### DIFF
--- a/AdvancedInterfaceOptions.toc
+++ b/AdvancedInterfaceOptions.toc
@@ -22,6 +22,7 @@ utils.lua
 cvars.lua
 
 gui\GeneralConfigPanel.lua
+gui\CameraConfigPanel.lua
 gui\ChatConfigPanel.lua
 gui\CombatConfigPanel.lua
 gui\FloatingCombatTextConfigPanel.lua

--- a/basicOptions.lua
+++ b/basicOptions.lua
@@ -99,6 +99,7 @@ function E:Init() -- Runs after our saved variables are loaded and cvars have be
 
   --Register our options with the Blizzard Addon Options panel
   AceConfigRegistry:RegisterOptionsTable("AdvancedInterfaceOptions", addon:CreateGeneralOptions())
+  AceConfigRegistry:RegisterOptionsTable("AdvancedInterfaceOptions_Camera", addon:CreateCameraOptions())
   AceConfigRegistry:RegisterOptionsTable("AdvancedInterfaceOptions_Chat", addon:CreateChatOptions())
   AceConfigRegistry:RegisterOptionsTable("AdvancedInterfaceOptions_Combat", addon:CreateCombatOptions())
   AceConfigRegistry:RegisterOptionsTable("AdvancedInterfaceOptions_FloatingCombatText", addon:CreateFloatingCombatTextOptions())
@@ -107,6 +108,7 @@ function E:Init() -- Runs after our saved variables are loaded and cvars have be
   AceConfigRegistry:RegisterOptionsTable("AdvancedInterfaceOptions_cVar", addon:CreateCVarOptions())
 
   local categoryFrame, mainCategoryID = AceConfigDialog:AddToBlizOptions("AdvancedInterfaceOptions", "AdvancedInterfaceOptions")
+  AceConfigDialog:AddToBlizOptions("AdvancedInterfaceOptions_Camera", "Camera", "AdvancedInterfaceOptions")
   AceConfigDialog:AddToBlizOptions("AdvancedInterfaceOptions_Chat", "Chat", "AdvancedInterfaceOptions")
   AceConfigDialog:AddToBlizOptions("AdvancedInterfaceOptions_Combat", "Combat", "AdvancedInterfaceOptions")
   AceConfigDialog:AddToBlizOptions("AdvancedInterfaceOptions_FloatingCombatText", "Floating Combat Text", "AdvancedInterfaceOptions")

--- a/gui/CameraConfigPanel.lua
+++ b/gui/CameraConfigPanel.lua
@@ -53,6 +53,10 @@ function addon:CreateCameraOptions()
         type = "header",
         name = "Camera Collision",
         order = 20,
+        --this feature is only supported in 11.0 at the moment
+        hidden = function()
+          return not addon.IsRetail()
+        end,
       },
       cameraIndirectVisibility = {
         type = "toggle",
@@ -63,6 +67,10 @@ function addon:CreateCameraOptions()
         end,
         set = function(_, value)
           self:SetCVar("cameraIndirectVisibility", value)
+        end,
+        --this feature is only supported in 11.0 at the moment
+        hidden = function()
+          return not addon.IsRetail()
         end,
         width = THIRD_WIDTH,
         order = 21,
@@ -82,6 +90,10 @@ function addon:CreateCameraOptions()
         end,
         disabled = function()
           return not C_CVar.GetCVarBool("cameraIndirectVisibility")
+        end,
+        --this feature is only supported in 11.0 at the moment
+        hidden = function()
+          return not addon.IsRetail()
         end,
         width = THIRD_WIDTH,
         order = 22,

--- a/gui/CameraConfigPanel.lua
+++ b/gui/CameraConfigPanel.lua
@@ -1,0 +1,124 @@
+local _, addon = ...
+
+-- Constants
+local THIRD_WIDTH = 1.25
+
+local maxCameraZoomFactor
+if not addon.IsRetail() then
+  maxCameraZoomFactor = 3.4
+else
+  maxCameraZoomFactor = 2.6
+end
+
+-------------------------------------------------------------------------
+-------------------------------------------------------------------------
+
+function addon:CreateCameraOptions()
+  local combatOptions = {
+    type = "group",
+    childGroups = "tree",
+    name = "Camera",
+    args = {
+      instructions = {
+        type = "description",
+        name = "These options allow you to modify Camera Options.",
+        fontSize = "medium",
+        order = 1,
+      },
+      -------------------------------------------------
+      header = {
+        type = "header",
+        name = "",
+        order = 10,
+      },
+      -- TODO: This might need more work for classic
+      cameraDistanceMaxZoomFactor = {
+        type = "range",
+        name = MAX_FOLLOW_DIST,
+        desc = OPTION_TOOLTIP_MAX_FOLLOW_DIST,
+        min = 1,
+        max = maxCameraZoomFactor,
+        step = 0.1,
+        get = function()
+          return tonumber(C_CVar.GetCVar("cameraDistanceMaxZoomFactor"))
+        end,
+        set = function(_, value)
+          self:SetCVar("cameraDistanceMaxZoomFactor", value)
+        end,
+        width = THIRD_WIDTH,
+        order = 11,
+      },
+      -------------------------------------------------
+      cameraCollisionHeader = {
+        type = "header",
+        name = "Camera Collision",
+        order = 20,
+      },
+      cameraIndirectVisibility = {
+        type = "toggle",
+        name = "Camera Indirect Visibility",
+        desc = "Allow for the player character to be more obstructed by the environment before colliding and pushing the camera forward.",
+        get = function()
+          return C_CVar.GetCVarBool("cameraIndirectVisibility")
+        end,
+        set = function(_, value)
+          self:SetCVar("cameraIndirectVisibility", value)
+        end,
+        width = THIRD_WIDTH,
+        order = 21,
+      },
+      cameraIndirectOffset = {
+        type = "range",
+        name = "Camera Indirect Offset",
+        desc = "Control the sensitivity threshold for camera collisions when 'Camera Indirect Visibility' is enabled. [0] is the most sensitive, [10] is the least sensitive.",
+        min = 1,
+        max = 10,
+        step = 0.1,
+        get = function()
+          return tonumber(C_CVar.GetCVar("cameraIndirectOffset"))
+        end,
+        set = function(_, value)
+          self:SetCVar("cameraIndirectOffset", value)
+        end,
+        disabled = function()
+          return not C_CVar.GetCVarBool("cameraIndirectVisibility")
+        end,
+        width = THIRD_WIDTH,
+        order = 22,
+      },
+      -------------------------------------------------
+      actionCameraHeader = {
+        type = "header",
+        name = "Action Camera",
+        order = 30,
+      },
+      actionCam = {
+        type = "select",
+        name = "Select Action Cam mode:",
+        desc = "Select the mode for the Action Cam.",
+        values = {
+          ["default"] = "Default",
+          ["on"] = "On",
+          ["basic"] = "Basic",
+          ["full"] = "Full",
+        },
+        sorting = {
+          "default",
+          "on",
+          "basic",
+          "full",
+        },
+        get = function()
+          return self.getActionCamMode()
+        end,
+        set = function(_, value)
+          ConsoleExec("actioncam" .. " " .. value)
+        end,
+        width = THIRD_WIDTH,
+        order = 31,
+      },
+    }
+  }
+
+  return combatOptions
+end

--- a/gui/CameraConfigPanel.lua
+++ b/gui/CameraConfigPanel.lua
@@ -14,7 +14,7 @@ end
 -------------------------------------------------------------------------
 
 function addon:CreateCameraOptions()
-  local combatOptions = {
+  local cameraOptions = {
     type = "group",
     childGroups = "tree",
     name = "Camera",
@@ -132,5 +132,5 @@ function addon:CreateCameraOptions()
     }
   }
 
-  return combatOptions
+  return cameraOptions
 end

--- a/gui/GeneralConfigPanel.lua
+++ b/gui/GeneralConfigPanel.lua
@@ -3,13 +3,6 @@ local _, addon = ...
 -- Constants
 local THIRD_WIDTH = 1.25
 
-local maxCameraZoomFactor
-if not addon.IsRetail() then
-  maxCameraZoomFactor = 3.4
-else
-  maxCameraZoomFactor = 2.6
-end
-
 -------------------------------------------------------------------------
 -------------------------------------------------------------------------
 
@@ -245,48 +238,6 @@ function addon:CreateGeneralOptions()
         end,
         width = THIRD_WIDTH,
         order = 31,
-      },
-      actionCam = {
-        type = "select",
-        name = "Select Action Cam mode:",
-        desc = "Select the mode for the Action Cam.",
-        values = {
-          ["default"] = "Default",
-          ["on"] = "On",
-          ["basic"] = "Basic",
-          ["full"] = "Full",
-        },
-        sorting = {
-          "default",
-          "on",
-          "basic",
-          "full",
-        },
-        get = function()
-          return self.getActionCamMode()
-        end,
-        set = function(_, value)
-          ConsoleExec("actioncam" .. " " .. value)
-        end,
-        width = THIRD_WIDTH,
-        order = 32,
-      },
-      -- TODO: This might need more work for classic
-      cameraDistanceMaxZoomFactor = {
-        type = "range",
-        name = MAX_FOLLOW_DIST,
-        desc = OPTION_TOOLTIP_MAX_FOLLOW_DIST,
-        min = 1,
-        max = maxCameraZoomFactor,
-        step = 0.1,
-        get = function()
-          return tonumber(C_CVar.GetCVar("cameraDistanceMaxZoomFactor"))
-        end,
-        set = function(_, value)
-          self:SetCVar("cameraDistanceMaxZoomFactor", value)
-        end,
-        width = THIRD_WIDTH,
-        order = 33,
       },
       -------------------------------------------------
       dataHeader = {


### PR DESCRIPTION
In 11.0 Blizzard added new camera collision options, and this patch adds in these new settings as well as moves other camera options into a dedicated "camera" panel.

Note: There seems to be some weird issue with Ace3 right now on sliders where it initially draws the slider value offset from its actual value. This can lead to the slider indicator appearing outside of bounds of the slider. I think this must be a new bug, because I've never seen it before. Hopefully it gets fixed soon.