### PR TITLE
Update TOC file for patch 11.2 Ghost of K'aresh

### DIFF
--- a/AdvancedInterfaceOptions.toc
+++ b/AdvancedInterfaceOptions.toc
@@ -1,4 +1,4 @@
-## Interface: 110107, 50500, 40402, 30404, 11506
+## Interface: 110200, 50500, 40402, 30404, 11506
 ## Title: Advanced Interface Options
 ## Author: Stanzilla, Semlar
 ## Version: @project-version@


### PR DESCRIPTION
Updated the ## Interface: version in the .toc file from 110107 to 110200 to reflect the new retail patch. This change prevents the addon from being flagged as "out of date" in the addons list.