### PR TITLE
chore: automate WoW interface updates

### DIFF
--- a/.github/workflows/update-wow-interface.yml
+++ b/.github/workflows/update-wow-interface.yml
@@ -1,0 +1,40 @@
+name: Update WoW TOC Interface
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * 1"
+
+permissions: {}
+
+concurrency:
+  group: wow-interface-updater
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update interface versions
+    if: github.repository == 'Stanzilla/AdvancedInterfaceOptions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push the update branch.
+      pull-requests: write # Required to open or update the pull request.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - id: toc
+        uses: Nnoggie/wow-interface-updater@9566e33fd0abb13201221f8f35fd93e7beef0129 # v1.1.0
+        with:
+          toc-glob: AdvancedInterfaceOptions.toc
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        if: steps.toc.outputs.changed == 'true'
+        with:
+          branch: automation/wow-interface
+          delete-branch: true
+          add-paths: AdvancedInterfaceOptions.toc
+          commit-message: "chore: update WoW interface versions"
+          title: "chore: update WoW interface versions"
+          body: ${{ steps.toc.outputs.pr-body }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 cvars2.dump
 debug.lua
 .vscode/

--- a/AdvancedInterfaceOptions.toc
+++ b/AdvancedInterfaceOptions.toc
@@ -1,4 +1,5 @@
-## Interface: 120000, 110200, 50503, 40402, 30404, 20506, 11509
+# WOW_INTERFACE_TARGETS: mainline-beta, mainline-test, mainline, mists-test, mists, cata, wrath, tbc-test, tbc, vanilla
+## Interface: 120100, 120007, 120001, 50504, 40402, 30405, 20506, 11509
 ## Title: Advanced Interface Options
 ## Author: Stanzilla, Semlar
 ## Version: @project-version@


### PR DESCRIPTION
## Summary

- annotate the universal TOC interface line with updater targets and refresh all supported client interface IDs
- add a manual and weekly updater workflow with immutable action pins, scoped permissions, and automated pull request creation
- ignore macOS .DS_Store metadata

## Validation

- updater rerun reported changed=false
- zizmor --strict-collection .github/workflows/update-wow-interface.yml reported no findings
- git diff --check passed
- independent review found no Critical or Required issues

## Note

Pull requests opened by the scheduled workflow with the repository GITHUB_TOKEN will not trigger ordinary pull_request workflows. A PAT or GitHub App token would be required if automated PRs must start those checks.