### PR TITLE
Guard the status text repaint against secret values

### DIFF
--- a/gui/StatusTextConfigPanel.lua
+++ b/gui/StatusTextConfigPanel.lua
@@ -52,7 +52,8 @@ local statusTextValues = {
 
 local function setStatusText(cvar, value)
   addon.setCustomVar(cvar, value)
-  statusTextValues[cvar](value and "statusText")
+  -- UpdateTextString reads values that are secret on a tainted stack, so it throws here
+  pcall(statusTextValues[cvar], value and "statusText")
 end
 
 -------------------------------------------------------------------------


### PR DESCRIPTION
Toggling a Status Text option calls UpdateTextString, so on 12.0 the values it reads are secret and TextStatusBar.lua:110 throws "attempt to compare a secret number value".

The bar's cvar field is set before that call, so pcall keeps the setting and drops the error.
